### PR TITLE
path fix for mac

### DIFF
--- a/mac/install-plugin.sh
+++ b/mac/install-plugin.sh
@@ -1,3 +1,5 @@
+ROOTPATH="$(pwd)"
+
 rm -rf /tmp/vcam-plugin.plugin
 mkdir /tmp/vcam-plugin.plugin
 cd /tmp/vcam-plugin.plugin
@@ -10,10 +12,10 @@ mkdir Resources
 cd ..
 cd ..
 
-cp "$1/libvcam-plugin.dylib" /tmp/vcam-plugin.plugin/Contents/MacOS/vcam-plugin
-cp "$1/vcam-assistant" /tmp/vcam-plugin.plugin/Contents/Resources/vcam-assistant
+cp "$ROOTPATH/libvcam-plugin.dylib" /tmp/vcam-plugin.plugin/Contents/MacOS/vcam-plugin
+cp "$ROOTPATH/vcam-assistant" /tmp/vcam-plugin.plugin/Contents/Resources/vcam-assistant
 
-cp "$1/Info.plist" /tmp/vcam-plugin.plugin/Contents/Info.plist
+cp "$ROOTPATH/Info.plist" /tmp/vcam-plugin.plugin/Contents/Info.plist
 
 rm -rf /Library/CoreMediaIO/Plug-Ins/DAL/vcam-plugin.plugin
 cp -a /tmp/vcam-plugin.plugin/. /Library/CoreMediaIO/Plug-Ins/DAL/vcam-plugin.plugin


### PR DESCRIPTION
install script fails on mac due to path issues. The pull request addresses the issue on mac devices. 